### PR TITLE
add live-server as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "html-linter": "^1.1.1",
+    "live-server": "^1.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1"
   }


### PR DESCRIPTION
using npm run develop fails if you do not have live server installed globally, having a live server dev dependency fixes it