### PR TITLE
Fix install dependencies command in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,7 @@
 3. Open up your terminal and cd into the gulpie project (the one you just downloaded and uncompressed).
 
 ### Install dependencies with: 
-`npm run install`
+`npm install`
 
 ### Fire up the server with:
-`
-  npm run develop
-`
+`npm run develop`


### PR DESCRIPTION
Dependencies are installed via `npm install`. `npm run install` would run a predefined script _install_ which is not there and leads to an error in execution.